### PR TITLE
Fixed double hyphen for output filename artifact being installed in Maven repo

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -2,7 +2,7 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 	<modelVersion>4.0.0</modelVersion>
 
-	<groupId>org.digitalmediaserver</groupId>
+	<groupId>com.quaytex.plugins</groupId>
 	<artifactId>nsis-maven-plugin</artifactId>
 	<version>1.0.1-SNAPSHOT</version>
 	<packaging>maven-plugin</packaging>
@@ -13,7 +13,7 @@
 	<name>NSIS Maven Plugin</name>
 
 	<description>This Maven plugin allows NSIS Windows installers to be built.</description>
-	<url>https://github.com/DigitalMediaServer/nsis-maven-plugin</url>
+	<url>https://github.com/gieza/nsis-maven-plugin</url>
 
 	<licenses>
 		<license>
@@ -24,10 +24,10 @@
 	</licenses>
 
 	<scm>
-		<connection>scm:git:git@github.com:DigitalMediaServer/nsis-maven-plugin.git</connection>
-		<developerConnection>scm:git:git@github.com:DigitalMediaServer/nsis-maven-plugin.git</developerConnection>
-		<url>http://github.com/DigitalMediaServer/nsis-maven-plugin</url>
-	</scm>
+  <connection>scm:git:git@github.com:gieza/nsis-maven-plugin.git</connection>
+  <developerConnection>scm:git:git@github.com:gieza/nsis-maven-plugin.git</developerConnection>
+  <url>http://github.com/gieza/nsis-maven-plugin</url>
+</scm>
 
 	<developers>
 		<developer>
@@ -44,7 +44,7 @@
 
 	<issueManagement>
 		<system>GitHub</system>
-		<url>https://github.com/DigitalMediaServer/nsis-maven-plugin/issues</url>
+		<url>https://github.com/gieza/nsis-maven-plugin/issues</url>
 	</issueManagement>
 
 	<properties>

--- a/src/main/java/org/digitalmediaserver/nsis/MakeMojo.java
+++ b/src/main/java/org/digitalmediaserver/nsis/MakeMojo.java
@@ -462,13 +462,14 @@ public class MakeMojo extends AbstractMojo implements ProcessOutputConsumer {
 		if (classifier == null || classifier.isEmpty()) {
 			return baseFolder == null ? path : baseFolder.resolve(path);
 		}
+		String classifierWithHyphenPrefix = classifier;
 		if (classifier.charAt(0) != '-') {
-			classifier = "-" + classifier;
+			classifierWithHyphenPrefix = "-" + classifier;
 		}
 		int dot = outputFile.lastIndexOf('.');
 		outputFile = dot >= 0 ?
-			outputFile.substring(0, dot) + classifier + outputFile.substring(dot) :
-				outputFile + classifier;
+			outputFile.substring(0, dot) + classifierWithHyphenPrefix + outputFile.substring(dot) :
+				outputFile + classifierWithHyphenPrefix;
 		return baseFolder == null ? Paths.get(outputFile) : baseFolder.resolve(outputFile);
 	}
 }


### PR DESCRIPTION
Double hyphen happens before classifier in the artifact filename, for the artifact being installed into Maven repository. 
This fixes issue #1

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/digitalmediaserver/nsis-maven-plugin/2)
<!-- Reviewable:end -->
