### PR TITLE
Fix NSISDIR autodetect on MacOS HomeBrew

### DIFF
--- a/src/main/java/org/digitalmediaserver/nsis/MakeMojo.java
+++ b/src/main/java/org/digitalmediaserver/nsis/MakeMojo.java
@@ -293,12 +293,25 @@ public class MakeMojo extends AbstractMojo implements ProcessOutputConsumer {
 			Path path = Paths.get(makensisExecutable);
 			makensisExecutable = path.toRealPath().toString();
 			if (autoNsisDir && isBlank(nsisDir)) {
+				if (Files.isSymbolicLink(path)) {
+					path = path.toRealPath();
+				}
 				path = path.getParent();
 				if (path != null) {
 					path = path.toRealPath();
 					Path fileName = path.getFileName();
 					if (fileName != null && "bin".equals(fileName.toString().toLowerCase(Locale.ROOT))) {
 						path = path.getParent();
+					}
+
+					// macOS Homebrew!
+					if (OSTYPE == OSType.MACOS) {
+						if (path.toString().contains("/Cellar/")) {
+							Path shareNsis = path.resolve("share/nsis");
+							if (Files.exists(shareNsis)) {
+								path = shareNsis;
+							}
+						}
 					}
 				}
 				nsisDir = path == null ? null : path.toString();

--- a/src/main/java/org/digitalmediaserver/nsis/MakeMojo.java
+++ b/src/main/java/org/digitalmediaserver/nsis/MakeMojo.java
@@ -291,7 +291,7 @@ public class MakeMojo extends AbstractMojo implements ProcessOutputConsumer {
 		// Convert path separators
 		try {
 			Path path = Paths.get(makensisExecutable).toRealPath();
-			makensisExecutable = path.toRealPath().toString();
+			makensisExecutable = path.toString();
 			if (autoNsisDir && isBlank(nsisDir)) {
 				if (Files.isSymbolicLink(path)) {
 					path = path.toRealPath();

--- a/src/main/java/org/digitalmediaserver/nsis/MakeMojo.java
+++ b/src/main/java/org/digitalmediaserver/nsis/MakeMojo.java
@@ -290,7 +290,7 @@ public class MakeMojo extends AbstractMojo implements ProcessOutputConsumer {
 
 		// Convert path separators
 		try {
-			Path path = Paths.get(makensisExecutable);
+			Path path = Paths.get(makensisExecutable).toRealPath();
 			makensisExecutable = path.toRealPath().toString();
 			if (autoNsisDir && isBlank(nsisDir)) {
 				if (Files.isSymbolicLink(path)) {

--- a/src/main/java/org/digitalmediaserver/nsis/MakeMojo.java
+++ b/src/main/java/org/digitalmediaserver/nsis/MakeMojo.java
@@ -293,9 +293,6 @@ public class MakeMojo extends AbstractMojo implements ProcessOutputConsumer {
 			Path path = Paths.get(makensisExecutable).toRealPath();
 			makensisExecutable = path.toString();
 			if (autoNsisDir && isBlank(nsisDir)) {
-				if (Files.isSymbolicLink(path)) {
-					path = path.toRealPath();
-				}
 				path = path.getParent();
 				if (path != null) {
 					path = path.toRealPath();
@@ -304,14 +301,10 @@ public class MakeMojo extends AbstractMojo implements ProcessOutputConsumer {
 						path = path.getParent();
 					}
 
-					// macOS Homebrew!
-					if (OSTYPE == OSType.MACOS) {
-						if (path.toString().contains("/Cellar/")) {
-							Path shareNsis = path.resolve("share/nsis");
-							if (Files.exists(shareNsis)) {
-								path = shareNsis;
-							}
-						}
+					// `/usr/local/bin` installations or macOS Homebrew keg-only
+					Path shareNsis = path.resolve("share/nsis");
+					if (Files.exists(shareNsis)) {
+						path = shareNsis;
 					}
 				}
 				nsisDir = path == null ? null : path.toString();


### PR DESCRIPTION
Previously the NSISDIR when `<autoNsisDir>true</autoNsisDir>` was set incorrectly for NSIS which is installed via HomeBrew on MacOS. You would get errors when `nsismake` was executed. This fixes that.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/digitalmediaserver/nsis-maven-plugin/3)
<!-- Reviewable:end -->
